### PR TITLE
feat: add cli-based vnc checker

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Tool-check-vnc Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
 # Tool Check VNC
 
-This repository contains a simple Python script that reads a list of VNC
-servers from `results.txt`, connects to each server using `vncdotool`, grabs a
-screenshot and sends the image to a Telegram chat.
+This project provides a small script that iterates over a list of VNC
+servers, captures a screenshot from each and forwards the image to either
+a Telegram chat or a Discord webhook.  The previous implementation
+depended on the heavy `vncdotool` and `python-telegram-bot` packages; the
+script now uses a light‑weight VNC client written with the Python
+standard library and the ubiquitous
+[`requests`](https://pypi.org/project/requests/) package to communicate
+with the selected notification service.
+
+The implementation supports the "None" and "VNC" authentication methods
+of the RFB protocol and is intended for quick checking tasks rather than
+as a full featured VNC client.
 
 ## Requirements
 
 - Python 3.8+
-- [`vncdotool`](https://github.com/sibson/vncdotool)
-- [`python-telegram-bot`](https://github.com/python-telegram-bot/python-telegram-bot)
+- [`requests`](https://pypi.org/project/requests/)
+- [`Pillow`](https://pypi.org/project/Pillow/)
+- [`pycryptodomex`](https://pypi.org/project/pycryptodomex/)
 
 Install the dependencies using pip:
 
 ```bash
-pip install vncdotool python-telegram-bot
+pip install requests Pillow pycryptodomex
 ```
 
 ## Preparing `results.txt`
@@ -30,24 +40,24 @@ Example:
 192.168.0.10:5900-null-[My Server]
 ```
 
-Only the first two dashes are treated as separators, so dashes in `<name>` are
-allowed.
-
-## Telegram configuration
-
-Set the following environment variables before running the script:
-
-- `TELEGRAM_BOT_TOKEN`: token of your Telegram bot
-- `TELEGRAM_CHAT_ID`: target chat ID
+Only the first two dashes are treated as separators, so dashes in
+`<name>` are allowed.
 
 ## Running the script
 
-After configuring the environment variables and preparing `results.txt`, run:
+Execute the script with the desired options:
 
 ```bash
-python tool.py
+python tool.py --input results.txt --service telegram --bot-token <TOKEN> --chat-id <CHAT_ID>
 ```
 
-The script will attempt to connect to each VNC server, capture a screenshot and
-send it to the configured Telegram chat.
+To send results to Discord instead:
+
+```bash
+python tool.py --input results.txt --service discord --webhook-url <URL>
+```
+
+`--input` defaults to `results.txt` if not specified.  The script will
+attempt to connect to each VNC server, grab a screenshot and send it to
+the configured chat or webhook.
 

--- a/tool.py
+++ b/tool.py
@@ -1,54 +1,244 @@
-import os
-import time
-from vncdotool import api
-from telegram import Bot
+"""VNC screenshot sender.
 
-# Path to the list of VNC servers
-RESULTS_FILE = "results.txt"
+This script reads a list of VNC targets, captures a screenshot from each
+server and forwards the image to either a Telegram chat or a Discord
+webhook.  It avoids using the `vncdotool` and `python-telegram-bot`
+libraries and instead relies on a minimal implementation of the VNC
+protocol together with the ubiquitous `requests` package for interacting
+with the chosen notification service.
 
-# Read the targets from RESULTS_FILE
-with open(RESULTS_FILE, "r", encoding="utf-8") as file:
-    lines = [ln.strip() for ln in file if ln.strip()]
+Only the "None" and "VNC" security types are supported.  The VNC
+implementation is intentionally small and therefore may not handle all
+edge cases of the protocol.
+"""
 
-# Hàm để kiểm tra VNC và chụp ảnh
-def check_vnc(ip, port, password, name):
-    try:
-        client = api.connect(f"{ip}::{port}", password=password)
-        time.sleep(5)
-        image_path = f"{name}.png"
-        client.captureScreen(image_path)
-        client.disconnect()
-        return image_path
-    except Exception as e:
-        print(f"Failed to connect to VNC {ip}:{port} with error: {e}")
-        return None
+from __future__ import annotations
 
-# Hàm gửi ảnh qua Telegram
-def send_telegram_photo(image_path, bot_token, chat_id):
-    bot = Bot(token=bot_token)
-    with open(image_path, "rb") as img:
-        bot.send_photo(chat_id=chat_id, photo=img)
+import argparse
+import socket
+import struct
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
 
-# Thông tin Telegram bot
-bot_token = os.getenv("TELEGRAM_BOT_TOKEN")
-chat_id = os.getenv("TELEGRAM_CHAT_ID")
+import requests
+from PIL import Image
 
-if not bot_token or not chat_id:
-    raise RuntimeError(
-        "Missing Telegram credentials. Set TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID"
+
+# ---------------------------------------------------------------------------
+# Utility functions
+
+
+def _read_exact(sock: socket.socket, n: int) -> bytes:
+    """Read exactly *n* bytes from *sock*.
+
+    Raises ``RuntimeError`` if the connection is closed prematurely.
+    """
+
+    data = bytearray()
+    while len(data) < n:
+        chunk = sock.recv(n - len(data))
+        if not chunk:
+            raise RuntimeError("Connection closed by remote host")
+        data.extend(chunk)
+    return bytes(data)
+
+
+def _encrypt_vnc_password(password: str, challenge: bytes) -> bytes:
+    """Return the DES encrypted challenge used by VNC authentication."""
+
+    from Cryptodome.Cipher import DES
+
+    key = password.encode("latin-1")[:8]
+    key = key.ljust(8, b"\x00")
+    # Reverse bits in each byte as required by the VNC spec
+    key = bytes(int(f"{b:08b}"[::-1], 2) for b in key)
+    cipher = DES.new(key, DES.MODE_ECB)
+    return cipher.encrypt(challenge)
+
+
+# ---------------------------------------------------------------------------
+# VNC client
+
+
+def capture_vnc_screen(
+    host: str,
+    port: int,
+    password: str,
+    timeout: float,
+) -> Image.Image:
+    """Capture a screenshot from the given VNC server.
+
+    The returned :class:`~PIL.Image.Image` object contains the framebuffer
+    captured using the "Raw" encoding.
+    """
+
+    sock = socket.create_connection((host, port), timeout=timeout)
+
+    # Protocol handshake
+    proto = _read_exact(sock, 12)
+    sock.sendall(proto)  # agree on server's version
+
+    version = proto[4:12]
+    major = int(version[:3])
+    minor = int(version[4:])
+
+    if major == 3 and minor >= 7:
+        num_types = _read_exact(sock, 1)[0]
+        sec_types = _read_exact(sock, num_types)
+        if 2 in sec_types and password:
+            sock.sendall(b"\x02")
+            challenge = _read_exact(sock, 16)
+            sock.sendall(_encrypt_vnc_password(password, challenge))
+        elif 1 in sec_types:
+            sock.sendall(b"\x01")
+        else:
+            raise RuntimeError("Unsupported security types")
+    else:  # protocol 3.3
+        sec_type = struct.unpack("!I", _read_exact(sock, 4))[0]
+        if sec_type == 2 and password:
+            challenge = _read_exact(sock, 16)
+            sock.sendall(_encrypt_vnc_password(password, challenge))
+        elif sec_type != 1:
+            raise RuntimeError("Unsupported security type")
+
+    # Security result
+    result = struct.unpack("!I", _read_exact(sock, 4))[0]
+    if result != 0:
+        raise RuntimeError("Authentication failed")
+
+    sock.sendall(b"\x01")  # ClientInit, request to share the session
+
+    # ServerInit
+    init = _read_exact(sock, 24)
+    width, height = struct.unpack("!HH", init[:4])
+    name_length = struct.unpack("!I", _read_exact(sock, 4))[0]
+    _read_exact(sock, name_length)  # skip desktop name
+
+    # SetPixelFormat (request 24-bit RGB little endian)
+    pixel_format = struct.pack(
+        "!BBBBHHHBBBxxx",
+        24,  # bits per pixel
+        24,  # depth
+        0,  # little endian
+        1,  # true colour
+        255,
+        255,
+        255,
+        16,
+        8,
+        0,
     )
+    sock.sendall(b"\x00\x00\x00\x00" + pixel_format)
 
-# Lặp qua các dòng và kiểm tra VNC
-for line in lines:
-    parts = line.split('-', 2)
-    if len(parts) == 3:
-        ip_port, password, name = parts
-        if ':' not in ip_port:
-            print(f"Invalid entry: {line}")
-            continue
-        ip, port = ip_port.split(':', 1)
-        name = name.strip('[]')
-        image_path = check_vnc(ip, port, password, name)
-        if image_path:
-            send_telegram_photo(image_path, bot_token, chat_id)
-            os.remove(image_path)
+    # SetEncodings (Raw)
+    sock.sendall(b"\x02\x00\x00\x01\x00\x00\x00\x00")
+
+    # FramebufferUpdateRequest for the entire screen
+    sock.sendall(b"\x03\x00" + struct.pack("!HHHH", 0, 0, width, height))
+
+    # FramebufferUpdate
+    if _read_exact(sock, 1) != b"\x00":
+        raise RuntimeError("Unexpected server message")
+    _read_exact(sock, 1)  # padding
+    num_rects = struct.unpack("!H", _read_exact(sock, 2))[0]
+
+    image = Image.new("RGB", (width, height))
+    for _ in range(num_rects):
+        rx, ry, rw, rh = struct.unpack("!HHHH", _read_exact(sock, 8))
+        encoding = struct.unpack("!i", _read_exact(sock, 4))[0]
+        if encoding != 0:
+            raise RuntimeError(f"Unsupported encoding: {encoding}")
+        pixel_bytes = _read_exact(sock, rw * rh * 3)
+        img = Image.frombytes("RGB", (rw, rh), pixel_bytes)
+        image.paste(img, (rx, ry))
+
+    sock.close()
+    return image
+
+
+# ---------------------------------------------------------------------------
+# Notification helpers
+
+
+def send_telegram_photo(image_path: Path, bot_token: str, chat_id: str) -> None:
+    """Send ``image_path`` to the specified Telegram chat."""
+
+    url = f"https://api.telegram.org/bot{bot_token}/sendPhoto"
+    with image_path.open("rb") as img:
+        response = requests.post(url, data={"chat_id": chat_id}, files={"photo": img})
+    response.raise_for_status()
+
+
+def send_discord_photo(image_path: Path, webhook_url: str) -> None:
+    """Send ``image_path`` to a Discord webhook."""
+
+    with image_path.open("rb") as img:
+        response = requests.post(webhook_url, files={"file": (image_path.name, img, "image/png")})
+    response.raise_for_status()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+
+
+def parse_targets(path: Path) -> Iterable[Tuple[str, int, str, str]]:
+    """Yield ``(ip, port, password, name)`` tuples from ``path``."""
+
+    with path.open("r", encoding="utf-8") as file:
+        for line in file:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split("-", 2)
+            if len(parts) != 3 or ":" not in parts[0]:
+                continue
+            ip, port = parts[0].split(":", 1)
+            password = parts[1]
+            name = parts[2].strip("[]")
+            yield ip, int(port), password, name
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Capture VNC screenshots")
+    parser.add_argument("--input", default="results.txt", help="Path to targets file")
+    parser.add_argument(
+        "--service",
+        choices=["telegram", "discord"],
+        default="telegram",
+        help="Notification service",
+    )
+    parser.add_argument("--bot-token", help="Telegram bot token")
+    parser.add_argument("--chat-id", help="Telegram chat ID")
+    parser.add_argument("--webhook-url", help="Discord webhook URL")
+    parser.add_argument("--timeout", type=float, default=10.0, help="Socket timeout")
+    args = parser.parse_args(argv)
+
+    if args.service == "telegram":
+        if not args.bot_token or not args.chat_id:
+            parser.error("--bot-token and --chat-id required for Telegram")
+    else:
+        if not args.webhook_url:
+            parser.error("--webhook-url required for Discord")
+
+    targets = list(parse_targets(Path(args.input)))
+    for ip, port, password, name in targets:
+        try:
+            image = capture_vnc_screen(ip, port, password, args.timeout)
+            image_path = Path(f"{name}.png")
+            image.save(image_path)
+            if args.service == "telegram":
+                send_telegram_photo(image_path, args.bot_token, args.chat_id)
+            else:
+                send_discord_photo(image_path, args.webhook_url)
+        except Exception as exc:  # pragma: no cover - best effort
+            print(f"Failed for {ip}:{port} - {exc}")
+        finally:
+            if "image_path" in locals() and image_path.exists():
+                image_path.unlink()
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- replace vncdotool-based script with lightweight VNC client using requests for Telegram
- expose configuration via CLI flags instead of environment variables
- add option to send screenshots via Telegram bot API or Discord webhook
- update README with new requirements and usage instructions
- add MIT license

## Testing
- `pip install requests Pillow pycryptodomex`
- `python -m py_compile tool.py`
- `python tool.py --help`


------
https://chatgpt.com/codex/tasks/task_b_689c3294141c83278160ccdb2c7e9e6b